### PR TITLE
Fix link from non-cussing site to cussing-site

### DIFF
--- a/layouts/shortcodes/other-version-link.html
+++ b/layouts/shortcodes/other-version-link.html
@@ -1,5 +1,5 @@
 {{ if .Page.Site.Params.UseCusses }}
 <p><strong>Need a version of the site without all of the cussing in the title? <a href="https://goshdarnformatstyle.com">Go to goshdarnformatstyle.com</a></strong><p>
 {{ else }}
-<p><strong>Need a version of the site with more cussing in the title? <a href="https://fuckingblocksyntax.com">Go to f*ckingformatstyle.com</a></strong><p>  
+<p><strong>Need a version of the site with more cussing in the title? <a href="https://fuckingformatstyle.com">Go to f*ckingformatstyle.com</a></strong><p>
 {{ end }}


### PR DESCRIPTION
The link at the top of goshdarnformatstyle was going to cussing`block syntax`.com, update to go to cussing`format style`.com instead.